### PR TITLE
Bump com.gradle.plugin-publish from 1.2.1 to 1.3.1

Bumps com.gradle.plugin-publish from 1.2.1 to 1.3.1.

---
updated-dependencies:
- dependency-name: com.gradle.plugin-publish
  dependency-version: 1.3.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Kotlin (Gradle)
+  - package-ecosystem: "gradle"
+    directory: "/" # adjust if your build.gradle is in a subdirectory
+    schedule:
+      interval: "weekly"
+
+  # Python
+  - package-ecosystem: "pip"
+    directory: "/" # adjust if your requirements.txt is in a subdirectory
+    schedule:
+      interval: "weekly"
+
+  # TypeScript (npm)
+  - package-ecosystem: "npm"
+    directory: "/" # adjust if your package.json is in a subdirectory
+    schedule:
+      interval: "weekly"
+
+  # C++ (GitHub Actions for CMake dependencies)
+  - package-ecosystem: "github-actions"
+    directory: "/" # for workflow dependencies
+    schedule:
+      interval: "weekly"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@
 plugins {
     `kotlin-dsl`
     `java-gradle-plugin`
-    id("com.gradle.plugin-publish") version "1.2.1"
+    id("com.gradle.plugin-publish") version "1.3.1"
 }
 
 // Define versions in the build file since buildSrc can't access the version catalog directly


### PR DESCRIPTION
@coderabbitai alright I think I got past that!  please  take a look at the colleb-canvas need to fix that build Gradle now